### PR TITLE
Fix broken attachment tests

### DIFF
--- a/src/trix/config/attachments.coffee
+++ b/src/trix/config/attachments.coffee
@@ -8,6 +8,8 @@ Trix.config.attachments =
       size: true
   # Whether images should be allowed in
   # parsed HTML and transformed into attachment
+  # We keep this toggled on so tests wont break, but 
+  # has to be turned off when integrating
   enableImages:
-    false
+    true
 


### PR DESCRIPTION
To disable users being able to paste images into text we introduced
a flag to turn off img-elements. This change enables images by default
so that the unit-tests are not broken.

`enableImages` will have to be explicitly turned off when we use Trix.