### PR TITLE
fix(pasting): fix issues with pasting

### DIFF
--- a/src/trix/config/block_attributes.coffee
+++ b/src/trix/config/block_attributes.coffee
@@ -1,9 +1,21 @@
 # Attribute explanation
 #
+# See https://github.com/basecamp/trix/pull/263 for origin of a lot of the 
+# attributes.
+#
 # `inheritFromPreviousBlock: boolean`
 # When the user has e.g. the end of a block selected, and presses return
 # this property will decide whether the block attribute should be copied
 # from the original block to the one that gets created.
+#
+# `terminal`: when a blockAttribute with terminal: true is applied, adding 
+# additional block attributes is prevented.
+#
+# `breakOnReturn`: when the return key is pressed from inside a block with
+#  breakOnReturn: true, the formatted block will be broken out of.
+#
+# `group`: prevents adjacent blocks with group: false from rendering in the 
+# same block element.
 
 Trix.config.blockAttributes = attributes =
   default:

--- a/src/trix/controllers/input_controller.coffee
+++ b/src/trix/controllers/input_controller.coffee
@@ -274,8 +274,20 @@ class Trix.InputController extends Trix.BasicObject
       else if html = clipboard.getData("text/html")
         paste.type = "text/html"
         paste.html = html
+        didDeleteSelection = false
+
+        # In the case of having an expanded selection, it should 
+        # have the same behavior as doing a deletion, and then pasting.
+        # Hence we do a deletion here, and pass along a flag to signal
+        # that we deleted the selection.
+        if @selectionIsExpanded()
+          selection = @delegate.editor.getSelectedRange()
+          @delegate.editor.deleteInDirection("backward")
+          @delegate.editor.setSelectedRange(selection[0])
+          didDeleteSelection = true
+        
         @delegate?.inputControllerWillPaste(paste)
-        @responder?.insertHTML(paste.html)
+        @responder?.insertHTML(paste.html, didDeleteSelection)
         @requestRender()
         @delegate?.inputControllerDidPaste(paste)
 

--- a/src/trix/core/helpers/config.coffee
+++ b/src/trix/core/helpers/config.coffee
@@ -2,6 +2,7 @@ allAttributeNames = null
 blockAttributeNames = null
 textAttributeNames = null
 listAttributeNames = null
+nestableAttributeNames = null
 
 Trix.extend
   getAllAttributeNames: ->
@@ -21,3 +22,7 @@ Trix.extend
 
   getListAttributeNames: ->
     listAttributeNames ?= (listAttribute for key, {listAttribute} of Trix.config.blockAttributes when listAttribute?)
+
+  getNestableAttributeNames: ->
+    nestableAttributeNames ?= (key for key, {nestable} of Trix.config.blockAttributes when nestable)
+


### PR DESCRIPTION
Issue 1: pasting headers into each could in some cases turn
into nested h-tags, e.g. h1 > h1. This was due to logic
in merging block attributes, where there was no proper check
for whether a block could have multiple heading attributes.

Issue 2: Selecting all content (e.g. via ctrl+A) and pasting
did not remove previous block attributes.
When pasting in this case all text would be removed. The
removal however did not account for actually removing the
block attributes as well: which meant that there could be
remnants of block attributes left before the new content was pasted:
for instance block alignments or heading attributes.

We fixed this by explicitly checking for whether everything
was being selected when pasting, and then having a special
case where we reset to a new fresh document without any attributes.