### PR TITLE
fix(lists): changed behaviour of backspace and lists

### DIFF
--- a/src/trix/models/composition.coffee
+++ b/src/trix/models/composition.coffee
@@ -141,6 +141,11 @@ class Trix.Composition extends Trix.BasicObject
 
         if block.isListItem()
           @decreaseListLevel()
+          # We return early here, so that for each list item
+          # the backspaces will keep removing a list level
+          # instead of removing a list level AND
+          # merging with the previous list item
+          return false
         else if block.isEmpty()
           # E.g. when we have a block that is set as blockquote
           # but with no content, pressing backspace should
@@ -148,6 +153,9 @@ class Trix.Composition extends Trix.BasicObject
           @decreaseBlockAttributeLevel()
 
         @setSelection(range[0])
+
+        # blocks where we have just deleted block attributes,
+        # and are now empty should remain
         return false if block.isEmpty()
 
     if selectionIsCollapsed

--- a/test/src/system/list_formatting_test.coffee
+++ b/test/src/system/list_formatting_test.coffee
@@ -36,7 +36,7 @@ testGroup "List formatting", template: "editor_empty", ->
         assert.blockAttributes([0, 2], ["bulletList", "bullet"])
         expectDocument("a\n\n")
 
-  test "pressing delete at the beginning of a non-empty nested list item", (expectDocument) ->
+  test "pressing backspace at the beginning of a non-empty nested list item", (expectDocument) ->
       clickToolbarButton attribute: "bullet", ->
         typeCharacters "a\n", ->
           clickToolbarButton action: "increaseNestingLevel", ->
@@ -48,8 +48,8 @@ testGroup "List formatting", template: "editor_empty", ->
                   getEditorController().render()
                   defer ->
                     assert.blockAttributes([0, 2], ["bulletList", "bullet"])
-                    assert.blockAttributes([3, 4], ["bulletList", "bullet", "bulletList", "bullet"])
-                    expectDocument("ab\nc\n")
+                    assert.blockAttributes([3, 4], ["bulletList", "bullet"])
+                    expectDocument("a\nb\nc\n")
 
   test "decreasing list item's level decreases its nested items level too", (expectDocument) ->
     clickToolbarButton attribute: "bullet", ->


### PR DESCRIPTION
Previously when we had a list like the following, Where
[] is the current selection:
```

* []a
```
and we pressed backspace, this would be the result:
```
a
```
I.e. it deletes both the list item, and the preceeding linebreak. In this case we don't want it to delete the linebreak.

This commit changes the behavior of pressing backspace
at the beginning of lists, so that each backspace
will remove one list level until the list element
is removed for that piece of text.

This was the preceeding linebreak is never removed,
and it will hopefully help users who are not very
adept at using using tab. Also works better on mobile.