### PR TITLE
test(lists): removed irrelevant test

### DIFF
--- a/test/src/system/block_formatting_test.coffee
+++ b/test/src/system/block_formatting_test.coffee
@@ -311,12 +311,6 @@ testGroup "Block formatting", template: "editor_empty", ->
         assert.blockAttributes([1, 2], [])
         done()
 
-  test "removing bullet from heading block", (done) ->
-    clickToolbarButton attribute: "bullet", ->
-      clickToolbarButton attribute: "heading1", ->
-        assert.ok isToolbarButtonDisabled(attribute: "bullet")
-        done()
-
   test "breaking out of heading in list", (expectDocument) ->
     clickToolbarButton attribute: "bullet", ->
       clickToolbarButton attribute: "heading1", ->


### PR DESCRIPTION
Previously made changes have altered the way Trix
keeps blocks from being blocks and headings at
the same time. This is not relevant for us, so we
remove this test.