### PR TITLE
feat: add instructions for publishing

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -1,0 +1,16 @@
+.github
+.blade.yml
+.gitignore
+.ruby-version
+.travis.yml
+.npmrc
+assets
+bin
+polyfills
+src
+test
+bower.json
+CODE_OF_CONDUCT.md
+config.ru
+Gemfile
+Gemfile.lock

--- a/.npmrc
+++ b/.npmrc
@@ -1,0 +1,1 @@
+//registry.npmjs.org/:_authToken=

--- a/README.md
+++ b/README.md
@@ -1,4 +1,22 @@
 # Trix
+
+### Fork notice
+
+This repository contains a forked version of the Trix text editor.
+
+At the time of the fork, Trix was the only text editor that came close to achieving decent compatibility with Android phones. More specifically most text editors had various kinds of issues with the GBoard keyboard used by default for some devices.
+
+Thus we created a fork of Trix, where some additional changes were made ontop of it to accomodate for our requirements.
+
+#### Publishing Changes
+
+The package is published to the private Jimdo npm registry.
+
+Instructions for publishing:
+1. Add an npm token to .npmrc which allows for publishing
+2. Verify changes by running `npm publish --dry-run`
+3. Run `npm publish`
+
 ### A Rich Text Editor for Everyday Writing
 
 **Compose beautifully formatted text in your web application.** Trix is a WYSIWYG editor for writing messages, comments, articles, and lists—the simple documents most web apps are made of. It features a sophisticated document model, support for embedded attachments, and outputs terse and consistent HTML.

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "trix",
+  "name": "@jimdo/trix",
   "version": "0.12.0",
   "description": "A rich text editor for everyday writing",
   "main": "dist/trix.js",
@@ -10,7 +10,7 @@
   ],
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/basecamp/trix.git"
+    "url": "git+https://github.com/Jimdo/trix"
   },
   "keywords": [
     "rich text",


### PR DESCRIPTION
# What was done

We've published the trix package to our private npm registry.

This PR contains changes necessary to do so.

It still involves some manual steps to do the publishing however,
since we don't want to setup the travis ci pipeline.